### PR TITLE
Fix readme table

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Himotoki also supports the following operators to decode JSON elements, where `T
 
 | Operator | Decode element as | Remarks                          |
 |:---------|:------------------|:---------------------------------|
-| `<|`     | `T`               | A value                          |
-| `<|?`    | `T?`              | An optional value                |
-| `<||`    | `[T]`             | An array of values               |
-| `<||?`   | `[T]?`            | An optional array of values      |
-| `<|-|`   | `[String: T]`     | A dictionary of values           |
-| `<|-|?`  | `[String: T]?`    | An optional dictionary of values |
+| `<\|`     | `T`               | A value                          |
+| `<\|?`    | `T?`              | An optional value                |
+| `<\|\|`    | `[T]`             | An array of values               |
+| `<\|\|?`   | `[T]?`            | An optional array of values      |
+| `<\|-\|`   | `[String: T]`     | A dictionary of values           |
+| `<\|-\|?`  | `[String: T]?`    | An optional dictionary of values |
 
 ## Value Transformation
 


### PR DESCRIPTION
## WHAT
Escape pipes in table markdown.

## WHY
Because the table was broken as below image.


<img width="392" alt="ikesyo_himotoki__a_type-safe_json_decoding_library_purely_written_in_swift" src="https://cloud.githubusercontent.com/assets/10217967/26526229/91b4580e-43ae-11e7-9e1c-90199fdf83d1.png">
